### PR TITLE
Fix contributing link and copyright in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ in progress
 
 1. Fork it (<https://github.com/finos/symphony-wdk-gallery/fork>)
 2. Create your feature branch (`git checkout -b feature/fooBar`)
-3. Read our [contribution guidelines](.github/CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
+3. Read our [contribution guidelines](CONTRIBUTING.md) and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 4. Commit your changes (`git commit -am 'Add some fooBar'`)
 5. Push to the branch (`git push origin feature/fooBar`)
 6. Create a new Pull Request
@@ -31,7 +31,7 @@ _NOTE:_ Commits and pull requests to FINOS repositories will only be accepted fr
 
 ## License
 
-Copyright {yyyy} {name of copyright owner}
+Copyright 2021 Symphony LLC
 
 Distributed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 


### PR DESCRIPTION
1. Contributing link was incorrectly pointing to .github sub-directory
2. Copyright notice was not defined